### PR TITLE
Include pthread.h when using pthread functions.

### DIFF
--- a/src/LocalControl.cpp
+++ b/src/LocalControl.cpp
@@ -9,6 +9,7 @@
 // [[Rcpp::plugins(cpp11)]]
 
 #include <Rcpp.h>
+#include <pthread.h>
 #include <unistd.h>
 
 using namespace Rcpp;


### PR DESCRIPTION
One should always include pthread.h when using pthread functions. Without this fix, compilation fails on LLVM/aarch64 (while it apparently happens to work on other platforms).